### PR TITLE
SignalRGB improvements and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ Another feature of the designer is that it is able to provide a detailed routing
 
 ![imgs/routing_detailed.png](imgs/routing_detailed.png)
 
-This scheme allows to locate each LED individually in the custom design. Furthermore, JSON files are produced that can be imported into SignalRGB to provide the necessary information to map each LED to a portion of the scene.
+This scheme allows to locate each LED individually in the custom design. Furthermore, JSON files are produced that can be imported into SignalRGB to provide the necessary information to map each LED to a portion of the scene. Four components are generated: one that closely resembles the detailed routing scheme, one that puts all LEDs belonging to a tile in its center (in this way, each tile has a uniform color), one that represent a single tile with LEDs on its border and one that represents a single tile, with LEDs in its center.
 
-For each given LED density, the routing scheme and the JSON file are generated respectively under the names `design_info/wp3_routing_XXX_leds_per_tile.pdf` and  `design_info/wp3_PROJECT-NAME_XXX_leds_signal_rgb.json`, where `XXX` is the number of LEDs that the designer determined can fit in a single panel.
+For each given LED density, the routing scheme and the JSON files are generated respectively under the names `design_info/wp3_routing_XXX_leds_per_tile.pdf` and  `design_info/wp3_signal_rgb_PROJECT-NAME_XXX_leds[VARIANT].json`, where `XXX` is the number of LEDs that the designer determined can fit in a single panel, `PROJECT-NAME` is, well, the name of the project and `[VARIANT]` is a string that depends on the type of exported component.
 
 
 #### Bill of materials
@@ -281,8 +281,13 @@ Grouped under `routing`.
 
 ### SignalRGB components settings
 
-| :construction: :construction_worker: work in progress: see [this issue](https://github.com/francofusco/wp3/issues/3). |
-| :-- |
+Grouped under `signal_rgb`.
+
+| Parameter | Type | Description |
+| :-------: | :--: | ----------- |
+| `name_prefix` | `str` | Optional. Prefix that should be used to identify the components inside SignalRGB. By default, the prefix is `WP3 PROJECT-NAME`.
+| `component_size` | `int` | Optional. Maximum width and height of the component inserted in SignalRGB's canvas, when unscaled. This applies to the largest dimension, the smallest will be evaluated to maintain the correct aspect ratio. |
+| `tile_size` | `int` | Optional. Maximum width and height of the single-tile component inserted in SignalRGB's canvas, when unscaled. This applies to the largest dimension, the smallest will be evaluated to maintain the correct aspect ratio. |
 
 
 ### Materials settings

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@
 	- [SignalRGB integration](#signalrgb-integration)
 		- [Preparing the Pico controller](#preparing-the-pico-controller)
 		- [Adding the panels into SignalRGB's layouts](#adding-the-panels-into-signalrgbs-layouts)
+- [Contributing and reporting issues](#contributing-and-reporting-issues)
+	- [Troubleshooting](#troubleshooting)
+	- [Instructions for developers](#instructions-for-developers)
 
 <!-- /TOC -->
 
@@ -472,3 +475,20 @@ Just for reference, this is how I created the cardboard walls:
 Depending on which LED density you decided to use, copy the corresponding json files into the directory `Documents\WhirlwindFX\Components` and restart SignalRGB. In the *Devices* page, click on the controller that you are using and click on the "+" button to add a component. In the brand filter, scroll down and look for *WP3*, then select the appropriate component. Go to the *Layouts* page and position the panels in the canvas. You are all set :partying_face:
 
 ![imgs/signal_rgb_integration.gif](imgs/signal_rgb_integration.gif)
+
+
+# Contributing and reporting issues
+
+## Troubleshooting
+
+If you happen to find a problem with the designer, do not hesitate to reach to me. The best way to do so is to [open an issue](https://github.com/francofusco/wp3/issues/new) describing the problem. Try to describe the problem you are facing, and perhaps include your `config.yaml`, as well as the log file `.wp3_last_run.log` that is generated after each time you run the designer.
+
+
+## Instructions for developers
+
+| :construction: :construction_worker: This section is to be written. |
+
+For the moment, I will just keep a short list of things that will be worth mentioning:
+
+- To create the executable you will need to download the PyInstaller package, *e.g.*, `pip install pyinstaller` or `conda install pyinstaller`. Once that is done, you can run (in an Anaconda terminal) the `build_exe.bat` script to create an executable under Windows.
+- While log files are generated automatically, you can also change verbosity level from the command line. Type `python wp3_designer.py --help` for the list of arguments that you can pass.

--- a/wp3/tile.py
+++ b/wp3/tile.py
@@ -165,6 +165,10 @@ class Tile(object):
         return type(self)(self.row, self.col, self.spacing, self.side_length,
                           self.variant)
 
+    def center(self):
+        """Center coordinates, as a NumPy array."""
+        return np.array([self.x, self.y])
+
     def vertices(self, border=1.0):
         """List of vertices, as a NumPy array.
 


### PR DESCRIPTION
This PR deals with the issues #3 and #8. In particular:

- Four components can now be imported into SignalRGB:
  - One component that closesly represents the composition of panels.
  - One component that is like the above, but with all LEDs of a tile mapped as if they were in the center of the tile.
  - Two components that represent a single tile each, with LEDs on the perimeter or center of the tile.
- Components can be slightly customized by slecting their minimum width and name.
- Logging capabilities have been added via the `logging` module. Messages are logged into two files (one that contains the messages from all previous runs and one that is limited to last execution) and also shown on stdout (with user-selectable severity).